### PR TITLE
Support musl

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -25,7 +25,12 @@ jobs:
         run: yarn install --ignore-scripts
 
       - name: Build addon
+        if: runner.os != 'Linux'
         run: make build-addon
+
+      - name: Build addon
+        if: runner.os == 'Linux'
+        run: make build-addon-linux
 
       - name: Get minimal Node.js version from package.json (Linux & macOS)
         id: node-version-nix

--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,7 @@ build
 node_modules
 prebuilds
 
+keccak-*.tgz
 npm-debug.log
 package-lock.json
 yarn-error.log

--- a/Makefile
+++ b/Makefile
@@ -3,11 +3,15 @@
 
 
 prebuildify = ./node_modules/.bin/prebuildify
+prebuildify-cross = ./node_modules/.bin/prebuildify-cross
 
 # hack, otherwise GitHub Actions for Windows:
 #  '.' is not recognized as an internal or external command, operable program or batch file.
 build-addon:
 	$(prebuildify) --target node@10.0.0 --napi --strip && node -p "process.platform"
+
+build-addon-linux:
+	$(prebuildify-cross) -i centos7-devtoolset7 -i alpine --target node@10.0.0 --napi --strip
 
 
 nyc = ./node_modules/.bin/nyc

--- a/package.json
+++ b/package.json
@@ -35,6 +35,7 @@
     "node-gyp": "^5.0.7",
     "nyc": "^15.0.0",
     "prebuildify": "^3.0.4",
+    "prebuildify-cross": "github:prebuild/prebuildify-cross#v4.0.0",
     "proxyquire": "^2.1.3",
     "standard": "^14.3.1",
     "tap-dot": "^2.0.0",


### PR DESCRIPTION
Ref. #15  Tested in `node:alpine` and `node` (glibc:2.24).

cc @wanseob @alcuadrado