### PR TITLE
fix: segfaults when used with worker_threads

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -14,12 +14,34 @@ jobs:
         os:
           - macos-latest
           - ubuntu-latest
-          - windows-latest
+          - windows-2019
     steps:
       - name: Fetch code
         uses: actions/checkout@v1
         with:
           submodules: true
+
+      - name: Get minimal Node.js version from package.json (Linux & macOS)
+        id: node-version-nix
+        if: runner.os != 'Windows'
+        run: echo "::set-output name=version::$(node -p 'require("./package.json").engines.node.match(/(\d+)\..*$/)[1]')"
+
+      - name: Use Node.js ${{ steps.node-version-nix.outputs.version }} (Linux & macOS)
+        if: runner.os != 'Windows'
+        uses: actions/setup-node@v1
+        with:
+          node-version: ${{ steps.node-version-nix.outputs.version }}
+
+      - name: Get minimal Node.js version from package.json (Windows)
+        id: node-version-win
+        if: runner.os == 'Windows'
+        run: echo "::set-output name=version::$(node -p 'require(\"./package.json\").engines.node.match(/(\d+)\..*$/)[1]')"
+
+      - name: Use Node.js ${{ steps.node-version-win.outputs.version }} (Windows)
+        if: runner.os == 'Windows'
+        uses: actions/setup-node@v1
+        with:
+          node-version: ${{ steps.node-version-win.outputs.version }}
 
       - name: Install dependencies
         run: yarn install --ignore-scripts
@@ -31,28 +53,6 @@ jobs:
       - name: Build addon
         if: runner.os == 'Linux'
         run: make build-addon-linux
-
-      - name: Get minimal Node.js version from package.json (Linux & macOS)
-        id: node-version-nix
-        if: runner.os != 'Windows'
-        run: echo "::set-output name=version::$(node -p 'require("./package.json").engines.node.match(/(\d.*)$/)[0]')"
-
-      - name: Use Node.js ${{ steps.node-version-nix.outputs.version }} (Linux & macOS)
-        if: runner.os != 'Windows'
-        uses: actions/setup-node@v1
-        with:
-          node-version: ${{ steps.node-version-nix.outputs.version }}
-
-      - name: Get minimal Node.js version from package.json (Windows)
-        id: node-version-win
-        if: runner.os == 'Windows'
-        run: echo "::set-output name=version::$(node -p 'require(\"./package.json\").engines.node.match(/(\d.*)$/)[0]')"
-
-      - name: Use Node.js ${{ steps.node-version-win.outputs.version }} (Windows)
-        if: runner.os == 'Windows'
-        uses: actions/setup-node@v1
-        with:
-          node-version: ${{ steps.node-version-win.outputs.version }}
 
       - name: Run tests for addon
         run: make test-tap

--- a/src/addon.cc
+++ b/src/addon.cc
@@ -12,7 +12,6 @@ class KeccakWrapper : public Napi::ObjectWrap<KeccakWrapper> {
 
  private:
   KeccakWidth1600_SpongeInstance sponge;
-  static Napi::FunctionReference constructor;
 
   Napi::Value Initialize(const Napi::CallbackInfo& info);
   Napi::Value Absorb(const Napi::CallbackInfo& info);
@@ -20,8 +19,6 @@ class KeccakWrapper : public Napi::ObjectWrap<KeccakWrapper> {
   Napi::Value Squeeze(const Napi::CallbackInfo& info);
   Napi::Value Copy(const Napi::CallbackInfo& info);
 };
-
-Napi::FunctionReference KeccakWrapper::constructor;
 
 Napi::Object KeccakWrapper::Init(Napi::Env env) {
   Napi::Function func =
@@ -35,9 +32,6 @@ Napi::Object KeccakWrapper::Init(Napi::Env env) {
                       InstanceMethod("squeeze", &KeccakWrapper::Squeeze),
                       InstanceMethod("copy", &KeccakWrapper::Copy),
                   });
-
-  constructor = Napi::Persistent(func);
-  constructor.SuppressDestruct();
 
   return func;
 }


### PR DESCRIPTION
This PR makes the lib more robust when used in combination with `worker_threads`.
We've observed that the usage of the global `constructor` field is not thread-safe and may lead to segfaults.

Fixes issue: #19

Minimal segfaulting example without this change:
```javascript
const wt = require('worker_threads');
const foo = require('keccak');

if(wt.isMainThread) {
  for(let i = 0; i < 100; i++) {
    new wt.Worker(__filename);
  }
}
```